### PR TITLE
fix: nightlies dont need docker hub login

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,11 +37,14 @@ jobs:
     - uses: docker/setup-qemu-action@v1
     - uses: docker/setup-buildx-action@v1
     - uses: docker/login-action@v1
+      name: ghcr.io login
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - uses: docker/login-action@v1
+      if: ${{ secrets.docker_username }} != ""
+      name: docker.io login
       with:
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_token }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,7 +45,6 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - uses: docker/login-action@v1
-      if: ${{ secrets.docker_username }} != ""
       name: docker.io login
       with:
         username: ${{ secrets.docker_username }}

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -92,7 +92,7 @@ snapshot:
   name_template: "{{ incpatch .Version }}-devel"
 
 nightly:
-  name_template: "devel-{{ .ShortCommit }}"
+  name_template: "{{ incpatch .Version }}-devel-{{ .ShortCommit }}"
 
 changelog:
   sort: asc
@@ -126,7 +126,7 @@ signs:
 
 dockers:
   - image_templates:
-      - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "{{ if not .IsNightly }}docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64{{ end }}"
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
     goarch: amd64
     build_flag_templates:
@@ -141,7 +141,7 @@ dockers:
     dockerfile: Dockerfile
     use: buildx
   - image_templates:
-      - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
+      - "{{ if not .IsNightly }}docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64{{ end }}"
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
     goarch: arm64
     build_flag_templates:
@@ -156,7 +156,7 @@ dockers:
     dockerfile: Dockerfile
     use: buildx
   - image_templates:
-      - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-armv7"
+      - "{{ if not .IsNightly }}docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-armv7{{ end }}"
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-armv7"
     goarch: arm
     goarm: "7"
@@ -173,7 +173,7 @@ dockers:
     use: buildx
 
 docker_manifests:
-  - name_template: "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:latest"
+  - name_template: "{{ if not .IsNightly }}docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:latest{{ end }}"
     image_templates:
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
@@ -183,7 +183,7 @@ docker_manifests:
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-armv7"
-  - name_template: "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}"
+  - name_template: "{{ if not .IsNightly }}docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}{{ end }}"
     image_templates:
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
@@ -193,7 +193,7 @@ docker_manifests:
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-armv7"
-  - name_template: "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}"
+  - name_template: "{{ if not .IsNightly }}docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}{{ end }}"
     image_templates:
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -92,7 +92,7 @@ snapshot:
   name_template: "{{ incpatch .Version }}-devel"
 
 nightly:
-  name_template: "{{ incpatch .Version }}-devel-{{ .ShortCommit }}"
+  name_template: "devel-{{ .ShortCommit }}"
 
 changelog:
   sort: asc
@@ -127,14 +127,14 @@ signs:
 dockers:
   - image_templates:
       - "{{ if not .IsNightly }}docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64{{ end }}"
-      - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
+      - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}-amd64"
     goarch: amd64
     build_flag_templates:
       - --platform=linux/amd64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.source={{ .GitURL }}
-      - --label=org.opencontainers.image.version=v{{ .Version }}
+      - --label=org.opencontainers.image.version={{ if not .IsNightly }}v{{ end }}{{ .Version }}
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
@@ -142,14 +142,14 @@ dockers:
     use: buildx
   - image_templates:
       - "{{ if not .IsNightly }}docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64{{ end }}"
-      - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
+      - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}-arm64"
     goarch: arm64
     build_flag_templates:
       - --platform=linux/arm64
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.source={{ .GitURL }}
-      - --label=org.opencontainers.image.version=v{{ .Version }}
+      - --label=org.opencontainers.image.version={{ if not .IsNightly }}v{{ end }}{{ .Version }}
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
@@ -157,7 +157,7 @@ dockers:
     use: buildx
   - image_templates:
       - "{{ if not .IsNightly }}docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-armv7{{ end }}"
-      - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-armv7"
+      - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}-armv7"
     goarch: arm
     goarm: "7"
     build_flag_templates:
@@ -165,7 +165,7 @@ dockers:
       - --label=org.opencontainers.image.title={{ .ProjectName }}
       - --label=org.opencontainers.image.description={{ .ProjectName }}
       - --label=org.opencontainers.image.source={{ .GitURL }}
-      - --label=org.opencontainers.image.version=v{{ .Version }}
+      - --label=org.opencontainers.image.version={{ if not .IsNightly }}v{{ end }}{{ .Version }}
       - --label=org.opencontainers.image.created={{ .Date }}
       - --label=org.opencontainers.image.revision={{ .FullCommit }}
       - --label=org.opencontainers.image.licenses=MIT
@@ -178,7 +178,7 @@ docker_manifests:
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-armv7"
-  - name_template: "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:latest"
+  - name_template: "{{ if not .IsNightly }}ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:latest{{ end }}"
     image_templates:
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
@@ -188,7 +188,7 @@ docker_manifests:
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-armv7"
-  - name_template: "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}"
+  - name_template: "{{ if not .IsNightly }}ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Major }}.{{ .Minor }}{{ end }}"
     image_templates:
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
@@ -198,7 +198,7 @@ docker_manifests:
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"
       - "docker.io/{{ .docker_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-armv7"
-  - name_template: "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}"
+  - name_template: "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}"
     image_templates:
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-amd64"
       - "ghcr.io/{{ .ghcr_io_registry_owner }}/{{ .ProjectName }}:v{{ .Version }}-arm64"


### PR DESCRIPTION
we were pushing just to ghcr before as well