### PR TITLE
feat: update to go 1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: build
 
 on:
   workflow_call:
+    inputs:
+      go_version:
+        required: true
+        type: string
+        default: ~1.18
     secrets:
       gh_pat:
         required: false
@@ -10,7 +15,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [~1.17, ^1]
+        go-version: ['${{ inputs.go_version }}', ^1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -2,6 +2,11 @@ name: goreleaser
 
 on:
   workflow_call:
+    inputs:
+      go_version:
+        required: true
+        type: string
+        default: 1.18
     secrets:
       docker_username:
         required: true
@@ -31,7 +36,7 @@ jobs:
         git config --global url."https://${{ secrets.gh_pat }}@github.com/charmbracelet".insteadOf "https://github.com/charmbracelet"
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: ${{ inputs.go_version }}
     - uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,11 @@ name: nightly
 
 on:
   workflow_call:
+    inputs:
+      go_version:
+        required: true
+        type: string
+        default: 1.18
     secrets:
       docker_username:
         required: true
@@ -38,7 +43,7 @@ jobs:
       if: env.GH_PAT != null
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: ${{ inputs.go_version }}
     - uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -2,6 +2,11 @@ name: snapshot
 
 on:
   workflow_call:
+    inputs:
+      go_version:
+        required: true
+        type: string
+        default: 1.18
     secrets:
       goreleaser_key:
         required: true
@@ -25,7 +30,7 @@ jobs:
       if: env.GH_PAT != null
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.17
+        go-version: ${{ inputs.go_version }}
     - uses: actions/cache@v3
       with:
         path: ~/go/pkg/mod


### PR DESCRIPTION
also made it possible to override the go version where the workflows are reused.  