### PR TITLE
fix: skip fury.io publish when env token doesn't exist

### DIFF
--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -89,7 +89,7 @@ nfpms:
         dst: /usr/share/man/man1/{{ .ProjectName }}.1.gz
 
 furies:
-  - account: charmcli
+  - account: '{{ with .Env.FURY_TOKEN }}charmcli{{ else }}{{ end }}'
     secret_name: FURY_TOKEN
 
 brews:

--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -98,7 +98,7 @@ nfpms:
         dst: /usr/share/man/man1/{{ .ProjectName }}.1.gz
 
 furies:
-  - account: charmcli
+  - account: '{{ with .Env.FURY_TOKEN }}charmcli{{ else }}{{ end }}'
     secret_name: FURY_TOKEN
 
 brews:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -67,7 +67,7 @@ nfpms:
       - rpm
 
 furies:
-  - account: charmcli
+  - account: '{{ with .Env.FURY_TOKEN }}charmcli{{ else }}{{ end }}'
     secret_name: FURY_TOKEN
 
 brews:


### PR DESCRIPTION
Skip publishing to fury.io when token is not set