### PR TITLE
feat: improve changelogs

### DIFF
--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -155,17 +155,28 @@ changelog:
   use: github
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
+    - '^test:'
+    - '^chore'
+    - 'merge conflict'
+    - Merge pull request
+    - Merge remote-tracking branch
+    - Merge branch
+    - go mod tidy
   groups:
+    - title: Dependency updates
+      regexp: "^.*feat\\(deps\\)*:+.*$"
+      order: 300
     - title: 'New Features'
       regexp: "^.*feat[(\\w)]*:+.*$"
-      order: 0
+      order: 100
     - title: 'Bug fixes'
       regexp: "^.*fix[(\\w)]*:+.*$"
-      order: 10
-    - title: Others
-      order: 999
+      order: 200
+    - title: 'Documentation updates'
+      regexp: "^.*docs[(\\w)]*:+.*$"
+      order: 400
+    - title: Other work
+      order: 9999
 
 signs:
   - cmd: cosign

--- a/goreleaser-lib.yaml
+++ b/goreleaser-lib.yaml
@@ -6,17 +6,28 @@ changelog:
   use: github
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
+    - '^test:'
+    - '^chore'
+    - 'merge conflict'
+    - Merge pull request
+    - Merge remote-tracking branch
+    - Merge branch
+    - go mod tidy
   groups:
+    - title: Dependency updates
+      regexp: "^.*feat\\(deps\\)*:+.*$"
+      order: 300
     - title: 'New Features'
       regexp: "^.*feat[(\\w)]*:+.*$"
-      order: 0
+      order: 100
     - title: 'Bug fixes'
       regexp: "^.*fix[(\\w)]*:+.*$"
-      order: 10
-    - title: Others
-      order: 999
+      order: 200
+    - title: 'Documentation updates'
+      regexp: "^.*docs[(\\w)]*:+.*$"
+      order: 400
+    - title: Other work
+      order: 9999
 release:
   footer: |
     * * *

--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -164,17 +164,28 @@ changelog:
   use: github
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
+    - '^test:'
+    - '^chore'
+    - 'merge conflict'
+    - Merge pull request
+    - Merge remote-tracking branch
+    - Merge branch
+    - go mod tidy
   groups:
+    - title: Dependency updates
+      regexp: "^.*feat\\(deps\\)*:+.*$"
+      order: 300
     - title: 'New Features'
       regexp: "^.*feat[(\\w)]*:+.*$"
-      order: 0
+      order: 100
     - title: 'Bug fixes'
       regexp: "^.*fix[(\\w)]*:+.*$"
-      order: 10
-    - title: Others
-      order: 999
+      order: 200
+    - title: 'Documentation updates'
+      regexp: "^.*docs[(\\w)]*:+.*$"
+      order: 400
+    - title: Other work
+      order: 9999
 
 signs:
   - cmd: cosign

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -112,17 +112,28 @@ changelog:
   use: github
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
+    - '^test:'
+    - '^chore'
+    - 'merge conflict'
+    - Merge pull request
+    - Merge remote-tracking branch
+    - Merge branch
+    - go mod tidy
   groups:
+    - title: Dependency updates
+      regexp: "^.*feat\\(deps\\)*:+.*$"
+      order: 300
     - title: 'New Features'
       regexp: "^.*feat[(\\w)]*:+.*$"
-      order: 0
+      order: 100
     - title: 'Bug fixes'
       regexp: "^.*fix[(\\w)]*:+.*$"
-      order: 10
-    - title: Others
-      order: 999
+      order: 200
+    - title: 'Documentation updates'
+      regexp: "^.*docs[(\\w)]*:+.*$"
+      order: 400
+    - title: Other work
+      order: 9999
 
 signs:
   - cmd: cosign


### PR DESCRIPTION
Improves the changelog a bit:

- removes merge commits and other not-very-useful lines
- better organize the output, with a new dependencies and documentation categories

fwiw this is the same config I use for goreleaser/goreleaser - example: https://github.com/goreleaser/goreleaser/releases/tag/v1.10.0

let me know what you think :)