### PR TITLE
fix: workaround goreleaser dirty git state

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -65,7 +65,7 @@ jobs:
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_token }}
     - run: |
-        echo "$NFPM_GPG_KEY" > ../gpg.key
+        echo "$NFPM_GPG_KEY" > ${{ runner.temp }}/gpg.key
       env:
         NFPM_GPG_KEY: ${{ secrets.nfpm_gpg_key }}
     - uses: goreleaser/goreleaser-action@v3
@@ -79,5 +79,5 @@ jobs:
         GORELEASER_KEY: ${{ secrets.goreleaser_key }}
         AUR_KEY: ${{ secrets.aur_key }}
         FURY_TOKEN: ${{ secrets.fury_token }}
-        GPG_KEY_PATH: ../gpg.key
+        GPG_KEY_PATH: ${{ runner.temp }}/gpg.key
         NFPM_DEFAULT_PASSPHRASE: ${{ secrets.nfpm_passphrase }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -65,7 +65,7 @@ jobs:
         username: ${{ secrets.docker_username }}
         password: ${{ secrets.docker_token }}
     - run: |
-        echo "$NFPM_GPG_KEY" > gpg.key
+        echo "$NFPM_GPG_KEY" > ../gpg.key
       env:
         NFPM_GPG_KEY: ${{ secrets.nfpm_gpg_key }}
     - uses: goreleaser/goreleaser-action@v3
@@ -79,5 +79,5 @@ jobs:
         GORELEASER_KEY: ${{ secrets.goreleaser_key }}
         AUR_KEY: ${{ secrets.aur_key }}
         FURY_TOKEN: ${{ secrets.fury_token }}
-        GPG_KEY_PATH: gpg.key
+        GPG_KEY_PATH: ../gpg.key
         NFPM_DEFAULT_PASSPHRASE: ${{ secrets.nfpm_passphrase }}


### PR DESCRIPTION
store gpg key in the parent directory, otherwise, goreleaser will error `git is currently in a dirty state`