### PR TITLE
fix: fish completions path

### DIFF
--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -82,7 +82,7 @@ nfpms:
       - src: ./completions/{{ .ProjectName }}.bash
         dst: /etc/bash_completion.d/{{ .ProjectName }}
       - src: ./completions/{{ .ProjectName }}.fish
-        dst: /usr/share/fish/completions/{{ .ProjectName }}.fish
+        dst: /usr/share/fish/vendor_completions.d/{{ .ProjectName }}.fish
       - src: ./completions/{{ .ProjectName }}.zsh
         dst: /usr/share/zsh/site-functions/_{{ .ProjectName }}
       - src: ./manpages/{{ .ProjectName }}.1.gz

--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -91,7 +91,7 @@ nfpms:
       - src: ./completions/{{ .ProjectName }}.bash
         dst: /etc/bash_completion.d/{{ .ProjectName }}
       - src: ./completions/{{ .ProjectName }}.fish
-        dst: /usr/share/fish/completions/{{ .ProjectName }}.fish
+        dst: /usr/share/fish/vendor_completions.d/{{ .ProjectName }}.fish
       - src: ./completions/{{ .ProjectName }}.zsh
         dst: /usr/share/zsh/site-functions/_{{ .ProjectName }}
       - src: ./manpages/{{ .ProjectName }}.1.gz


### PR DESCRIPTION
they should be at `vendor_completions.d`: https://fishshell.com/docs/current/completions.html#where-to-put-completions