### PR TITLE
fix: duplicated builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: ['${{ inputs.go_version }}', ^1]
+        go-version: ['${{ inputs.go_version }}']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
this is triggering ^1 multiple times

ideally, we should make inputs.go_version an array, I think... not sure the impact of it though... cc/ @aymanbagabas 