### PR TITLE
feat: add scoop pipeline

### DIFF
--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -116,6 +116,18 @@ brews:
       fish_completion.install "completions/{{ .ProjectName }}.fish"
       man1.install "manpages/{{ .ProjectName }}.1.gz"
 
+scoop:
+  bucket:
+    owner: '{{ .Var.brew_owner }}'
+    name: scoop-bucket
+    token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+  commit_author:
+    name: '{{ .Var.brew_commit_author_name }}'
+    email: '{{ .Var.brew_commit_author_email }}'
+  homepage: '{{ .Var.homepage }}'
+  description: '{{ .Var.description }}'
+  license: MIT
+
 aurs:
   - maintainers: ['{{ .Var.maintainer }}']
     description: '{{ .Var.description }}'

--- a/goreleaser-glow.yaml
+++ b/goreleaser-glow.yaml
@@ -116,6 +116,18 @@ brews:
       fish_completion.install "completions/{{ .ProjectName }}.fish"
       man1.install "manpages/{{ .ProjectName }}.1.gz"
 
+scoop:
+  bucket:
+    owner: '{{ .Var.brew_owner }}'
+    name: scoop-bucket
+    token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+  commit_author:
+    name: '{{ .Var.brew_commit_author_name }}'
+    email: '{{ .Var.brew_commit_author_email }}'
+  homepage: '{{ .Var.homepage }}'
+  description: '{{ .Var.description }}'
+  license: MIT
+
 aurs:
   - maintainers: ['{{ .Var.maintainer }}']
     description: '{{ .Var.description }}'

--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -125,6 +125,18 @@ brews:
       fish_completion.install "completions/{{ .ProjectName }}.fish"
       man1.install "manpages/{{ .ProjectName }}.1.gz"
 
+scoop:
+  bucket:
+    owner: '{{ .Var.brew_owner }}'
+    name: scoop-bucket
+    token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+  commit_author:
+    name: '{{ .Var.brew_commit_author_name }}'
+    email: '{{ .Var.brew_commit_author_email }}'
+  homepage: '{{ .Var.homepage }}'
+  description: '{{ .Var.description }}'
+  license: MIT
+
 aurs:
   - maintainers: ['{{ .Var.maintainer }}']
     description: '{{ .Var.description }}'

--- a/goreleaser-soft-serve.yaml
+++ b/goreleaser-soft-serve.yaml
@@ -120,6 +120,18 @@ brews:
       fish_completion.install "completions/{{ .ProjectName }}.fish"
       man1.install "manpages/{{ .ProjectName }}.1.gz"
 
+scoop:
+  bucket:
+    owner: '{{ .Var.brew_owner }}'
+    name: scoop-bucket
+    token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+  commit_author:
+    name: '{{ .Var.brew_commit_author_name }}'
+    email: '{{ .Var.brew_commit_author_email }}'
+  homepage: '{{ .Var.homepage }}'
+  description: '{{ .Var.description }}'
+  license: MIT
+
 aurs:
   - maintainers: ['{{ .Var.maintainer }}']
     description: '{{ .Var.description }}'

--- a/goreleaser-vhs.yaml
+++ b/goreleaser-vhs.yaml
@@ -119,6 +119,18 @@ brews:
       fish_completion.install "completions/{{ .ProjectName }}.fish"
       man1.install "manpages/{{ .ProjectName }}.1.gz"
 
+scoop:
+  bucket:
+    owner: '{{ .Var.brew_owner }}'
+    name: scoop-bucket
+    token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+  commit_author:
+    name: '{{ .Var.brew_commit_author_name }}'
+    email: '{{ .Var.brew_commit_author_email }}'
+  homepage: '{{ .Var.homepage }}'
+  description: '{{ .Var.description }}'
+  license: MIT
+
 aurs:
   - maintainers: ['{{ .Var.maintainer }}']
     description: '{{ .Var.description }}'

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -88,6 +88,18 @@ brews:
     homepage: '{{ .Var.homepage }}'
     description: '{{ .Var.description }}'
 
+scoop:
+  bucket:
+    owner: '{{ .Var.brew_owner }}'
+    name: scoop-bucket
+    token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+  commit_author:
+    name: '{{ .Var.brew_commit_author_name }}'
+    email: '{{ .Var.brew_commit_author_email }}'
+  homepage: '{{ .Var.homepage }}'
+  description: '{{ .Var.description }}'
+  license: MIT
+
 aurs:
   - maintainers: ['{{ .Var.maintainer }}']
     description: '{{ .Var.description }}'


### PR DESCRIPTION
Adds a Scoop pipeline to publish Scoop app manifests.
Uses the same Homebrew variables since they're technically the same.

https://github.com/charmbracelet/scoop-bucket