### PR TITLE
fix: force use snap 6.x until they fix their stuff

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -84,7 +84,7 @@ jobs:
         echo "$NFPM_GPG_KEY" > ${{ runner.temp }}/gpg.key
       env:
         NFPM_GPG_KEY: ${{ secrets.nfpm_gpg_key }}
-    - run: sudo snap install snapcraft --classic
+    - run: sudo snap install snapcraft --classic --channel=6.x/stable
     - run: |
         echo "$SNAPCRAFT_TOKEN" | snapcraft login --with -
       env:


### PR DESCRIPTION
currently auth with 0.7 is not working properly... this will force use of 6.x, which should still work.

https://forum.snapcraft.io/t/craft-store-error-credentials-found-for-snapcraft-on-dashboard-snapcraft-io/33549