### PR TITLE
fix: use conventional file names for nfpm packages

### DIFF
--- a/goreleaser-glow.yaml
+++ b/goreleaser-glow.yaml
@@ -74,6 +74,7 @@ nfpms:
     homepage: '{{ .Var.homepage }}'
     maintainer: '{{ .Var.maintainer }}'
     description: '{{ .Var.description }}'
+    file_name_template: '{{ .ConventionalFileName }}'
     license: MIT
     formats:
       - apk


### PR DESCRIPTION
refs https://github.com/charmbracelet/glow/issues/448

this will use the conventional file name for each format/arch as filename in the nfpm files.

an example of what it looks like: https://github.com/goreleaser/goreleaser/releases/tag/v1.14.1