### PR TITLE
fix: signing for newer cosign versions

### DIFF
--- a/goreleaser-enterprise.yaml
+++ b/goreleaser-enterprise.yaml
@@ -40,14 +40,13 @@ nightly:
 
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     certificate: '${artifact}.pem'
     args:
       - sign-blob
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
+      - '--yes'
     artifacts: checksum
     output: true
 
@@ -86,13 +85,12 @@ docker_manifests:
 
 docker_signs:
   - cmd: cosign
-    env:
-     - COSIGN_EXPERIMENTAL=1
     artifacts: manifests
     output: true
     args:
       - 'sign'
       - '${artifact}'
+      - '--yes'
 
 release:
   footer: |

--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -200,14 +200,13 @@ changelog:
 
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     certificate: '${artifact}.pem'
     args:
       - sign-blob
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
+      - '--yes'
     artifacts: checksum
     output: true
 
@@ -293,13 +292,12 @@ docker_manifests:
 
 docker_signs:
   - cmd: cosign
-    env:
-     - COSIGN_EXPERIMENTAL=1
     artifacts: manifests
     output: true
     args:
       - 'sign'
       - '${artifact}'
+      - '--yes'
 
 release:
   footer: |

--- a/goreleaser-glow.yaml
+++ b/goreleaser-glow.yaml
@@ -189,14 +189,13 @@ changelog:
 
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     certificate: '${artifact}.pem'
     args:
       - sign-blob
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
+      - '--yes'
     artifacts: checksum
     output: true
 
@@ -282,13 +281,12 @@ docker_manifests:
 
 docker_signs:
   - cmd: cosign
-    env:
-     - COSIGN_EXPERIMENTAL=1
     artifacts: manifests
     output: true
     args:
       - 'sign'
       - '${artifact}'
+      - '--yes'
 
 release:
   footer: |

--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -204,14 +204,13 @@ changelog:
 
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     certificate: '${artifact}.pem'
     args:
       - sign-blob
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
+      - '--yes'
     artifacts: checksum
     output: true
 
@@ -297,13 +296,12 @@ docker_manifests:
 
 docker_signs:
   - cmd: cosign
-    env:
-     - COSIGN_EXPERIMENTAL=1
     artifacts: manifests
     output: true
     args:
       - 'sign'
       - '${artifact}'
+      - '--yes'
 
 release:
   footer: |

--- a/goreleaser-soft-serve.yaml
+++ b/goreleaser-soft-serve.yaml
@@ -206,14 +206,13 @@ changelog:
 
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     certificate: '${artifact}.pem'
     args:
       - sign-blob
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
+      - '--yes'
     artifacts: checksum
     output: true
 
@@ -299,13 +298,12 @@ docker_manifests:
 
 docker_signs:
   - cmd: cosign
-    env:
-     - COSIGN_EXPERIMENTAL=1
     artifacts: manifests
     output: true
     args:
       - 'sign'
       - '${artifact}'
+      - '--yes'
 
 release:
   footer: |

--- a/goreleaser-vhs.yaml
+++ b/goreleaser-vhs.yaml
@@ -206,14 +206,13 @@ changelog:
 
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     certificate: '${artifact}.pem'
     args:
       - sign-blob
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
+      - '--yes'
     artifacts: checksum
     output: true
 
@@ -277,13 +276,12 @@ docker_manifests:
 
 docker_signs:
   - cmd: cosign
-    env:
-     - COSIGN_EXPERIMENTAL=1
     artifacts: manifests
     output: true
     args:
       - 'sign'
       - '${artifact}'
+      - '--yes'
 
 release:
   footer: |

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -157,14 +157,13 @@ changelog:
 
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     certificate: '${artifact}.pem'
     args:
       - sign-blob
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
+      - '--yes'
     artifacts: checksum
     output: true
 
@@ -250,13 +249,12 @@ docker_manifests:
 
 docker_signs:
   - cmd: cosign
-    env:
-     - COSIGN_EXPERIMENTAL=1
     artifacts: manifests
     output: true
     args:
       - 'sign'
       - '${artifact}'
+      - '--yes'
 
 release:
   footer: |


### PR DESCRIPTION
new cosign versions need a `--yes` flag to auto-accept prompts, and don't need the experimental env anymore, as the features we used are no longer experimental :)