### PR TITLE
build: add a job to check all config files

### DIFF
--- a/.github/workflows/goreleaser-deprecation-check.yml
+++ b/.github/workflows/goreleaser-deprecation-check.yml
@@ -1,0 +1,15 @@
+name: goreleaser-deprecation-check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser-pro
+          args: check -q --glob 'goreleaser*.yaml'


### PR DESCRIPTION
this will use an upcoming goreleaser-pro feature to check all files for deprecations and invalid configuration.

To be merged only after goreleaser 1.18