### PR TITLE
feat: properly handle chore(deps)

### DIFF
--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -218,7 +218,7 @@ changelog:
       - go mod tidy
   groups:
     - title: Dependency updates
-      regexp: "^.*feat\\(deps\\)*:+.*$"
+      regexp: "^.*\\(deps\\)*:+.*$"
       order: 300
     - title: "New Features"
       regexp: "^.*feat[(\\w)]*:+.*$"

--- a/goreleaser-lib.yaml
+++ b/goreleaser-lib.yaml
@@ -17,7 +17,7 @@ changelog:
       - go mod tidy
   groups:
     - title: Dependency updates
-      regexp: "^.*feat\\(deps\\)*:+.*$"
+      regexp: "^.*\\(deps\\)*:+.*$"
       order: 300
     - title: "New Features"
       regexp: "^.*feat[(\\w)]*:+.*$"

--- a/goreleaser-mods.yaml
+++ b/goreleaser-mods.yaml
@@ -201,7 +201,7 @@ changelog:
       - go mod tidy
   groups:
     - title: Dependency updates
-      regexp: "^.*feat\\(deps\\)*:+.*$"
+      regexp: "^.*\\(deps\\)*:+.*$"
       order: 300
     - title: "New Features"
       regexp: "^.*feat[(\\w)]*:+.*$"

--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -221,7 +221,7 @@ changelog:
       - go mod tidy
   groups:
     - title: Dependency updates
-      regexp: "^.*feat\\(deps\\)*:+.*$"
+      regexp: "^.*\\(deps\\)*:+.*$"
       order: 300
     - title: "New Features"
       regexp: "^.*feat[(\\w)]*:+.*$"

--- a/goreleaser-simple.yaml
+++ b/goreleaser-simple.yaml
@@ -172,7 +172,7 @@ changelog:
       - go mod tidy
   groups:
     - title: Dependency updates
-      regexp: "^.*feat\\(deps\\)*:+.*$"
+      regexp: "^.*\\(deps\\)*:+.*$"
       order: 300
     - title: "New Features"
       regexp: "^.*feat[(\\w)]*:+.*$"

--- a/goreleaser-soft-serve.yaml
+++ b/goreleaser-soft-serve.yaml
@@ -241,7 +241,7 @@ changelog:
       - go mod tidy
   groups:
     - title: Dependency updates
-      regexp: "^.*feat\\(deps\\)*:+.*$"
+      regexp: "^.*\\(deps\\)*:+.*$"
       order: 300
     - title: "New Features"
       regexp: "^.*feat[(\\w)]*:+.*$"

--- a/goreleaser-vhs.yaml
+++ b/goreleaser-vhs.yaml
@@ -230,7 +230,7 @@ changelog:
       - go mod tidy
   groups:
     - title: Dependency updates
-      regexp: "^.*feat\\(deps\\)*:+.*$"
+      regexp: "^.*\\(deps\\)*:+.*$"
       order: 300
     - title: "New Features"
       regexp: "^.*feat[(\\w)]*:+.*$"

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -173,7 +173,7 @@ changelog:
       - go mod tidy
   groups:
     - title: Dependency updates
-      regexp: "^.*feat\\(deps\\)*:+.*$"
+      regexp: "^.*\\(deps\\)*:+.*$"
       order: 300
     - title: "New Features"
       regexp: "^.*feat[(\\w)]*:+.*$"


### PR DESCRIPTION
In some projects we already moved the dependabot configs to chore instead of feat, this fixes the changelog grouping to comport it.