### PR TITLE
fix(soft-serve): bash is a not a scoop package

### DIFF
--- a/goreleaser-soft-serve.yaml
+++ b/goreleaser-soft-serve.yaml
@@ -150,7 +150,6 @@ scoops:
     license: MIT
     depends:
       - git
-      - bash
 
 aurs:
   - maintainers: ["{{ .Var.maintainer }}"]


### PR DESCRIPTION
refs https://github.com/charmbracelet/scoop-bucket/pull/4