### PR TITLE
fix: drop windows 386 from goreleaser-semi

### DIFF
--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -51,6 +51,8 @@ builds:
         goarch: arm64
       - goos: windows
         goarm: "7"
+      - goos: windows
+        goarch: "386"
       - goos: freebsd
         goarch: arm64
       - goos: freebsd


### PR DESCRIPTION
Fixes: https://github.com/charmbracelet/charm/pull/258