### PR TITLE
fix: extract to directory; no more tarbombs

### DIFF
--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -68,6 +68,7 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- with .Arm}}v{{ . }}{{ end }}
+    wrap_in_directory: true
     files:
       - README*
       - LICENSE*

--- a/goreleaser-glow.yaml
+++ b/goreleaser-glow.yaml
@@ -65,6 +65,7 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    wrap_in_directory: true
     files:
       - README*
       - LICENSE*

--- a/goreleaser-mods.yaml
+++ b/goreleaser-mods.yaml
@@ -57,6 +57,7 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    wrap_in_directory: true
     files:
       - README*
       - LICENSE*

--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -71,6 +71,7 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    wrap_in_directory: true
     files:
       - README*
       - LICENSE*

--- a/goreleaser-simple.yaml
+++ b/goreleaser-simple.yaml
@@ -49,6 +49,7 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    wrap_in_directory: true
     files:
       - README*
       - LICENSE*

--- a/goreleaser-soft-serve.yaml
+++ b/goreleaser-soft-serve.yaml
@@ -66,6 +66,8 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    # love, not tarbombs <3
+    wrap_in_directory: true
     files:
       - README*
       - LICENSE*

--- a/goreleaser-vhs.yaml
+++ b/goreleaser-vhs.yaml
@@ -62,6 +62,7 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    wrap_in_directory: true
     files:
       - README*
       - LICENSE*

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -58,6 +58,7 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    wrap_in_directory: true
 
 nfpms:
   - vendor: charmbracelet


### PR DESCRIPTION
## Related:

https://github.com/charmbracelet/mods/issues/90

He's right, it would be frustrating for users to have files consistently
overwritten if they are using the archives to install from source. I changed
all archives to output to directories, feel free to change if it's overkill in
some of these cases.

## Resources

https://goreleaser.com/customization/archive/?h=wrap_in
