### PR TITLE
feat: enable prerelease detection in goreleaser

### DIFF
--- a/goreleaser-enterprise.yaml
+++ b/goreleaser-enterprise.yaml
@@ -97,6 +97,9 @@ docker_signs:
       - "${artifact}"
       - "--yes"
 
+git:
+  tag_sort: semver
+
 release:
   prerelease: auto
   footer:

--- a/goreleaser-enterprise.yaml
+++ b/goreleaser-enterprise.yaml
@@ -98,6 +98,7 @@ docker_signs:
       - "--yes"
 
 release:
+  prerelease: auto
   footer:
     from_url:
       url: https://raw.githubusercontent.com/charmbracelet/meta/main/footer.md

--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -352,6 +352,7 @@ docker_signs:
       - "--yes"
 
 release:
+  prerelease: auto
   footer:
     from_url:
       url: https://raw.githubusercontent.com/charmbracelet/meta/main/footer.md

--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -351,6 +351,9 @@ docker_signs:
       - "${artifact}"
       - "--yes"
 
+git:
+  tag_sort: semver
+
 release:
   prerelease: auto
   footer:

--- a/goreleaser-glow.yaml
+++ b/goreleaser-glow.yaml
@@ -328,6 +328,9 @@ docker_signs:
       - "${artifact}"
       - "--yes"
 
+git:
+  tag_sort: semver
+
 release:
   prerelease: auto
   footer:

--- a/goreleaser-glow.yaml
+++ b/goreleaser-glow.yaml
@@ -329,6 +329,7 @@ docker_signs:
       - "--yes"
 
 release:
+  prerelease: auto
   footer:
     from_url:
       url: https://raw.githubusercontent.com/charmbracelet/meta/main/footer.md

--- a/goreleaser-lib.yaml
+++ b/goreleaser-lib.yaml
@@ -33,6 +33,7 @@ changelog:
       order: 9999
 
 release:
+  prerelease: auto
   footer:
     from_url:
       url: https://raw.githubusercontent.com/charmbracelet/meta/main/footer_lib.md

--- a/goreleaser-lib.yaml
+++ b/goreleaser-lib.yaml
@@ -32,6 +32,9 @@ changelog:
     - title: Other work
       order: 9999
 
+git:
+  tag_sort: semver
+
 release:
   prerelease: auto
   footer:

--- a/goreleaser-mods.yaml
+++ b/goreleaser-mods.yaml
@@ -245,6 +245,7 @@ signs:
     output: true
 
 release:
+  prerelease: auto
   footer:
     from_url:
       url: https://raw.githubusercontent.com/charmbracelet/meta/main/footer.md

--- a/goreleaser-mods.yaml
+++ b/goreleaser-mods.yaml
@@ -244,6 +244,9 @@ signs:
     artifacts: checksum
     output: true
 
+git:
+  tag_sort: semver
+
 release:
   prerelease: auto
   footer:

--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -349,6 +349,7 @@ docker_signs:
       - "--yes"
 
 release:
+  prerelease: auto
   footer:
     from_url:
       url: https://raw.githubusercontent.com/charmbracelet/meta/main/footer.md

--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -348,6 +348,9 @@ docker_signs:
       - "${artifact}"
       - "--yes"
 
+git:
+  tag_sort: semver
+
 release:
   prerelease: auto
   footer:

--- a/goreleaser-simple.yaml
+++ b/goreleaser-simple.yaml
@@ -210,6 +210,9 @@ signs:
     artifacts: checksum
     output: true
 
+git:
+  tag_sort: semver
+
 release:
   prerelease: auto
   footer:

--- a/goreleaser-simple.yaml
+++ b/goreleaser-simple.yaml
@@ -211,6 +211,7 @@ signs:
     output: true
 
 release:
+  prerelease: auto
   footer:
     from_url:
       url: https://raw.githubusercontent.com/charmbracelet/meta/main/footer.md

--- a/goreleaser-soft-serve.yaml
+++ b/goreleaser-soft-serve.yaml
@@ -366,6 +366,7 @@ docker_signs:
       - "--yes"
 
 release:
+  prerelease: auto
   footer:
     from_url:
       url: https://raw.githubusercontent.com/charmbracelet/meta/main/footer.md

--- a/goreleaser-soft-serve.yaml
+++ b/goreleaser-soft-serve.yaml
@@ -365,6 +365,9 @@ docker_signs:
       - "${artifact}"
       - "--yes"
 
+git:
+  tag_sort: semver
+
 release:
   prerelease: auto
   footer:

--- a/goreleaser-vhs.yaml
+++ b/goreleaser-vhs.yaml
@@ -333,6 +333,9 @@ docker_signs:
       - "${artifact}"
       - "--yes"
 
+git:
+  tag_sort: semver
+
 release:
   prerelease: auto
   footer:

--- a/goreleaser-vhs.yaml
+++ b/goreleaser-vhs.yaml
@@ -334,6 +334,7 @@ docker_signs:
       - "--yes"
 
 release:
+  prerelease: auto
   footer:
     from_url:
       url: https://raw.githubusercontent.com/charmbracelet/meta/main/footer.md

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -294,6 +294,9 @@ docker_signs:
       - "${artifact}"
       - "--yes"
 
+git:
+  tag_sort: semver
+
 release:
   prerelease: auto
   footer:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -295,6 +295,7 @@ docker_signs:
       - "--yes"
 
 release:
+  prerelease: auto
   footer:
     from_url:
       url: https://raw.githubusercontent.com/charmbracelet/meta/main/footer.md


### PR DESCRIPTION
This makes GoReleaser automatically detect prereleases based on the Git version tag.