### PR TITLE
ignore govulncheck for non-stable go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   govulncheck:
+    if: inputs.go_version == "stable" || inputs.go-version == "stable"
     runs-on: ubuntu-latest
     env:
       GH_PAT: ${{ secrets.gh_pat }}


### PR DESCRIPTION
`go install govulncheck` doesn't seem to work when built with Go 1.19, blocking https://github.com/charmbracelet/log/pull/141 for example.

It seems like there's no real benefit to running govulncheck for any non-stable Go version (correct me if I'm wrong).

I wasn't sure whether `go-version` or `go_version` were preferred, so I supported both.