### PR TITLE
feat(ci): add golangci-lint config and shared workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,64 @@
+name: lint
+on:
+  workflow_call:
+
+permissions:
+  # Required: allow read access to the content for analysis.
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+  # Optional: allow write access to checks to allow the action to annotate code in the PR.
+  checks: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - uses: actions/checkout@v4
+        with:
+          path: ${{ github.repository }}
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/meta
+          path: ${{ github.repository_owner }}/meta
+      - run: |
+          pwd
+          tree
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: ${{ github.repository }}
+          # Optional: golangci-lint command line arguments.
+          args: |
+            --config="${{ github.workspace }}/${{ github.repository_owner }}/meta/golangci.yml"
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true
+
+  lint-soft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - uses: actions/checkout@v4
+        with:
+          path: ${{ github.repository }}
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/meta
+          path: ${{ github.repository_owner }}/meta
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: ${{ github.repository }}
+          # Optional: golangci-lint command line arguments.
+          args: |
+            --config="${{ github.workspace }}/${{ github.repository_owner }}/meta/golangci-soft.yml" \
+            --issues-exit-code=0
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true

--- a/golangci-soft.yml
+++ b/golangci-soft.yml
@@ -1,0 +1,40 @@
+run:
+  tests: false
+
+issues:
+  include:
+    - EXC0001
+    - EXC0005
+    - EXC0011
+    - EXC0012
+    - EXC0013
+
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  enable:
+    - exhaustive
+    - goconst
+    - godot
+    - godox
+    - mnd
+    - gomoddirectives
+    - goprintffuncname
+    - misspell
+    - nakedret
+    - nestif
+    - noctx
+    - nolintlint
+    - prealloc
+    - wrapcheck
+
+  # disable default linters, they are already enabled in .golangci.yml
+  disable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused

--- a/golangci.yml
+++ b/golangci.yml
@@ -1,0 +1,29 @@
+run:
+  tests: false
+
+issues:
+  include:
+    - EXC0001
+    - EXC0005
+    - EXC0011
+    - EXC0012
+    - EXC0013
+
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  enable:
+    - bodyclose
+    - gofumpt
+    - goimports
+    - gosec
+    - nilerr
+    - predeclared
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - tparallel
+    - unconvert
+    - unparam
+    - whitespace


### PR DESCRIPTION
This adds a shared workflow for linting Go code using golangci-lint. It adds golangci-lint configuration files for both the default and soft linting configurations and clones the meta repository to use the configuration files when running the workflow.

The golangci-lint configs were taken from bubbletea.

Repositories can then run the workflow using the following:
```yaml
name: lint
on:
  push:
  pull_request:

jobs:
  lint:
    uses: charmbracelet/meta/.github/workflows/lint.yml@main
```

