### PR TITLE
fix(ci): lint configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,6 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
       - uses: actions/checkout@v4
         with:
           path: ${{ github.repository }}
@@ -28,6 +24,10 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/meta
           path: ${{ github.repository_owner }}/meta
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
@@ -44,10 +44,6 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
       - uses: actions/checkout@v4
         with:
           path: ${{ github.repository }}
@@ -55,6 +51,10 @@ jobs:
         with:
           repository: ${{ github.repository_owner }}/meta
           path: ${{ github.repository_owner }}/meta
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/golangci-soft.yml
+++ b/golangci-soft.yml
@@ -36,5 +36,4 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused


### PR DESCRIPTION
`typecheck` cannot be disabled because it's not linter, so the configuration is misleading because this has no effect.

- https://golangci-lint.run/welcome/faq/#why-is-it-not-possible-to-skipignore-typecheck-errors
- https://golangci-lint.run/welcome/faq/#why-do-you-have-typecheck-errors

---

The action `actions/setup-go@v5` should be run after `actions/checkout@v4` for cache optimization.
