### PR TITLE
fix(lint): set core.autocrlf to input

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      # By default, the GitHub Action on Windows uses `core.autocrlf=true`.
+      # LF is converted to CRLF, this produces reports from formatters (gofmt/gofumpt/etc.).
+      - run: 'git config --global core.autocrlf input'
       - uses: actions/checkout@v4
         with:
           path: ${{ github.repository }}
@@ -42,6 +45,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      # By default, the GitHub Action on Windows uses `core.autocrlf=true`.
+      # LF is converted to CRLF, this produces reports from formatters (gofmt/gofumpt/etc.).
+      - run: 'git config --global core.autocrlf input'
       - uses: actions/checkout@v4
         with:
           path: ${{ github.repository }}


### PR DESCRIPTION
My PR #177 proves that the problem on Windows is not intermittent but consistent.
My initial guess was a problem with CRLF (Windows style) and I was right.

The problem is related to the `core.autocrlf`, by default, the GitHub Action on Windows uses `core.autocrlf=true`.
LF is converted to CRLF, and this produces file differences, so formatter like gofmt/gofumpt will report a problem.

Demo:
- The run fails: https://github.com/ldez/bubbletea/commit/b739658d6e0dd3dc849e251293725f48f62d55e1 https://github.com/ldez/bubbletea/actions/runs/11630127913
- The run works: https://github.com/ldez/bubbletea/commit/74a21c5f894c74b900afa1172f7a7b7d89252309  https://github.com/ldez/bubbletea/actions/runs/11630166096

Related to https://github.com/golangci/golangci-lint/issues/4004#issuecomment-2450731967