### PR TITLE
docs: fix spelling for GoReleaser, GitHub in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repo contains Charm’s meta configuration files:
 
-- goreleaser configurations
-- github actions workflows
+- GoReleaser configurations
+- GitHub Actions workflows
 
 ## Related docs
 


### PR DESCRIPTION
Change README:

- goreleaser - GoReleaser
- gitHub actions -> GitHub Actions