### PR TITLE
Passing timeout arg to golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
           working-directory: ${{ github.repository }}
           # Optional: golangci-lint command line arguments.
           args: |
-            --config="${{ github.workspace }}/${{ github.repository_owner }}/meta/golangci.yml"
+            --config="${{ github.workspace }}/${{ github.repository_owner }}/meta/golangci.yml" --timeout=5m 
 
   lint-soft:
     strategy:


### PR DESCRIPTION
The default timeout value of 1 minute is occasionally insufficient to complete the linting step in PRs.

https://github.com/charmbracelet/bubbletea/actions/runs/11873938591/job/33089318570?pr=1241#step:6:32

`msg="Timeout exceeded: try increasing it by passing --timeout option"`
