### PR TITLE
chore(goreleaser): create releases as draft

### DIFF
--- a/goreleaser-enterprise.yaml
+++ b/goreleaser-enterprise.yaml
@@ -101,6 +101,7 @@ git:
   tag_sort: semver
 
 release:
+  draft: true
   prerelease: auto
   footer:
     from_url:

--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -355,6 +355,7 @@ git:
   tag_sort: semver
 
 release:
+  draft: true
   prerelease: auto
   footer:
     from_url:

--- a/goreleaser-glow.yaml
+++ b/goreleaser-glow.yaml
@@ -332,6 +332,7 @@ git:
   tag_sort: semver
 
 release:
+  draft: true
   prerelease: auto
   footer:
     from_url:

--- a/goreleaser-lib.yaml
+++ b/goreleaser-lib.yaml
@@ -36,6 +36,7 @@ git:
   tag_sort: semver
 
 release:
+  draft: true
   prerelease: auto
   footer:
     from_url:

--- a/goreleaser-mods.yaml
+++ b/goreleaser-mods.yaml
@@ -248,6 +248,7 @@ git:
   tag_sort: semver
 
 release:
+  draft: true
   prerelease: auto
   footer:
     from_url:

--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -352,6 +352,7 @@ git:
   tag_sort: semver
 
 release:
+  draft: true
   prerelease: auto
   footer:
     from_url:

--- a/goreleaser-sequin.yaml
+++ b/goreleaser-sequin.yaml
@@ -254,6 +254,7 @@ git:
   tag_sort: semver
 
 release:
+  draft: true
   prerelease: auto
   footer:
     from_url:

--- a/goreleaser-simple.yaml
+++ b/goreleaser-simple.yaml
@@ -214,6 +214,7 @@ git:
   tag_sort: semver
 
 release:
+  draft: true
   prerelease: auto
   footer:
     from_url:

--- a/goreleaser-soft-serve.yaml
+++ b/goreleaser-soft-serve.yaml
@@ -369,6 +369,7 @@ git:
   tag_sort: semver
 
 release:
+  draft: true
   prerelease: auto
   footer:
     from_url:

--- a/goreleaser-vhs.yaml
+++ b/goreleaser-vhs.yaml
@@ -337,6 +337,7 @@ git:
   tag_sort: semver
 
 release:
+  draft: true
   prerelease: auto
   footer:
     from_url:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -298,6 +298,7 @@ git:
   tag_sort: semver
 
 release:
+  draft: true
   prerelease: auto
   footer:
     from_url:


### PR DESCRIPTION
We always edit the release title and description, so it is better to create the release as a draft and then we'll just mark as public once ready.

One real benefit of this is that people that watch our repositories receive an email about the release as soon as it becomes public, and this email will contain the actual title and description IIRC. By only publishing when ready, we ensure they receive our crafted description on their email, instead of the GoReleaser autogenerated description.