### PR TITLE
feat: add script to run `lint-sync` for all repos

### DIFF
--- a/scripts/run-lint-sync.sh
+++ b/scripts/run-lint-sync.sh
@@ -1,0 +1,10 @@
+# NOTE(@andreynering): This script runs the `lint-sync.yml` workflow for
+# all public repositories.
+
+REPOS=$(gh repo list charmbracelet --visibility public --no-archived --limit 1000 --json "name" -t '{{range .}}{{printf "%s\n" .name}}{{end}}')
+REPOS=$(echo "$REPOS" | awk '$0 != "x" && $0 != ".github" && $0 != "meta" && $0 != "homebrew-tap" && $0 != "scoop-bucket"' | sort)
+
+for repo in $REPOS; do
+  echo "Dispatching lint-sync.yml for $repo"
+  gh workflow run -R charmbracelet/$repo lint-sync.yml
+done


### PR DESCRIPTION
[We have a similar script for Dependabot already.](https://github.com/charmbracelet/meta/blob/main/dependabot/run-workflow.sh)