### PR TITLE
chore(lint): do not exclude paths (added on conversion)

### DIFF
--- a/golangci.yml
+++ b/golangci.yml
@@ -30,10 +30,6 @@ linters:
     generated: lax
     presets:
       - common-false-positives
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
@@ -43,7 +39,3 @@ formatters:
     - goimports
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$


### PR DESCRIPTION
Context: https://github.com/charmbracelet/glow/pull/735#discussion_r2027136655

We do have have `builtin` and `third_party` dirs, and I think we probably want to keep the `examples` dir in a good state, so removing them all.