### PR TITLE
fix: consistent dependabot commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,5 +37,5 @@ updates:
     labels:
       - "dependencies"
     commit-message:
-      prefix: "feat"
+      prefix: "chore"
       include: "scope"

--- a/dependabot/dependabot.yml
+++ b/dependabot/dependabot.yml
@@ -37,5 +37,5 @@ updates:
     labels:
       - "dependencies"
     commit-message:
-      prefix: "feat"
+      prefix: "chore"
       include: "scope"


### PR DESCRIPTION
not sure why docker deps were getting the `feat` marker, lowered it to `chore` as the rest of the dep systems.

