### PR TITLE
fix: do not throw lint errors on TODO

### DIFF
--- a/golangci.yml
+++ b/golangci.yml
@@ -7,7 +7,6 @@ linters:
     - exhaustive
     - goconst
     - godot
-    - godox
     - gomoddirectives
     - goprintffuncname
     - gosec
@@ -30,11 +29,6 @@ linters:
     generated: lax
     presets:
       - common-false-positives
-  settings:
-    godox:
-      keywords:
-        - BUG
-        - FIXME
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/golangci.yml
+++ b/golangci.yml
@@ -30,6 +30,11 @@ linters:
     generated: lax
     presets:
       - common-false-positives
+  settings:
+    godox:
+      keywords:
+        - BUG
+        - FIXME
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0


### PR DESCRIPTION
We commonly left TODOs in the code for the future, no reason to break the build over them.

See: https://golangci-lint.run/usage/linters/#godox