### PR TITLE
fix: temp disable noctx

### DIFF
--- a/golangci.yml
+++ b/golangci.yml
@@ -14,7 +14,7 @@ linters:
     - nakedret
     - nestif
     - nilerr
-    - noctx
+    # - noctx - XXX: slog breaks everywhere, need to do this slowly.
     - nolintlint
     - prealloc
     - revive


### PR DESCRIPTION
Recent golangci-lint update introduces this, which breaks everything.

We can re-add it later on a per-repo basis.

FWIW, assuming `ctx` is available, you can do it with:

```sh
gofmt -w -r 'slog.Error(a) -> slog.ErrorContext(ctx, a)' .
```
