### PR TITLE
chore: use a fixed golangci-lint version and allow override

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,10 @@ on:
         type: string
         required: false
         description: Path to golangci.yml
+      golangci_version:
+        type: string
+        required: false
+        description: Version of golangci-lint to use.
 
 permissions:
   # Required: allow read access to the content for analysis.
@@ -47,3 +51,4 @@ jobs:
           working-directory: ${{ github.repository }}
           args: |
             --config="${{ inputs.golangci_path || format('{0}/{1}/meta/golangci.yml', github.workspace, github.repository_owner) }}" --timeout=5m ${{ inputs.directory }}
+          version: ${{ inputs.golangci_version || 'v2.2' }}


### PR DESCRIPTION
Proposal for discussion. Avoid surprise lint failures in our repos.

Con is that we'll need to update this manually from time to time.