### PR TITLE
chore: update domain to `charm.land` on goreleaser and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ variables:
   description: ""
   github_url: ""
   maintainer: ""
-  homepage: "https://charm.sh/"
+  homepage: "https://charm.land/"
   brew_commit_author_name: ""
   brew_commit_author_email: ""
   brew_owner: charmbracelet
@@ -109,9 +109,9 @@ jobs:
 
 ---
 
-Part of [Charm](https://charm.sh).
+Part of [Charm](https://charm.land).
 
-<a href="https://charm.sh/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge.jpg" width="400"></a>
+<a href="https://charm.land/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge.jpg" width="400"></a>
 
 <!-- prettier-ignore -->
 Charm热爱开源 • Charm loves open source

--- a/footer.md
+++ b/footer.md
@@ -30,6 +30,6 @@ Done! You artifacts are now verified!
 
 </details>
 
-<a href="https://charm.sh/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge.jpg" width="400"></a>
+<a href="https://charm.land/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge.jpg" width="400"></a>
 
 Thoughts? Questions? We love hearing from you. Feel free to reach out on [Twitter](https://twitter.com/charmcli), [The Fediverse](https://mastodon.technology/@charm), or on [Discord](https://charm.sh/chat).

--- a/footer_lib.md
+++ b/footer_lib.md
@@ -1,5 +1,5 @@
 ---
 
-<a href="https://charm.sh/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge.jpg" width="400"></a>
+<a href="https://charm.land/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge.jpg" width="400"></a>
 
 Thoughts? Questions? We love hearing from you. Feel free to reach out on [Twitter](https://twitter.com/charmcli), [The Fediverse](https://mastodon.technology/@charm), or on [Discord](https://charm.sh/chat).

--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -6,7 +6,7 @@ variables:
   binary_name: ""
   description: ""
   maintainer: ""
-  homepage: "https://charm.sh/"
+  homepage: "https://charm.land/"
   brew_commit_author_name: ""
   brew_commit_author_email: ""
   brew_owner: charmbracelet

--- a/goreleaser-glow.yaml
+++ b/goreleaser-glow.yaml
@@ -4,7 +4,7 @@ version: 2
 variables:
   description: ""
   maintainer: ""
-  homepage: "https://charm.sh/"
+  homepage: "https://charm.land/"
   brew_commit_author_name: ""
   brew_commit_author_email: ""
   brew_owner: charmbracelet

--- a/goreleaser-mods.yaml
+++ b/goreleaser-mods.yaml
@@ -5,7 +5,7 @@ variables:
   main: ""
   aur_project_name: ""
 
-  homepage: "https://charm.sh/"
+  homepage: "https://charm.land/"
   brew_owner: charmbracelet
   description: "AI on the command line"
   github_url: "https://github.com/charmbracelet/mods"

--- a/goreleaser-semi.yaml
+++ b/goreleaser-semi.yaml
@@ -6,7 +6,7 @@ variables:
   binary_name: ""
   description: ""
   maintainer: ""
-  homepage: "https://charm.sh/"
+  homepage: "https://charm.land/"
   brew_commit_author_name: ""
   brew_commit_author_email: ""
   brew_owner: charmbracelet

--- a/goreleaser-sequin.yaml
+++ b/goreleaser-sequin.yaml
@@ -5,7 +5,7 @@ variables:
   main: ""
   aur_project_name: ""
 
-  homepage: "https://charm.sh/"
+  homepage: "https://charm.land/"
   brew_owner: charmbracelet
   description: "Human-readable ANSI sequences."
   github_url: "https://github.com/charmbracelet/sequin"

--- a/goreleaser-simple.yaml
+++ b/goreleaser-simple.yaml
@@ -6,7 +6,7 @@ variables:
   binary_name: ""
   description: ""
   maintainer: ""
-  homepage: "https://charm.sh/"
+  homepage: "https://charm.land/"
   brew_commit_author_name: ""
   brew_commit_author_email: ""
   brew_owner: charmbracelet

--- a/goreleaser-soft-serve.yaml
+++ b/goreleaser-soft-serve.yaml
@@ -7,7 +7,7 @@ variables:
   description: ""
   github_url: ""
   maintainer: ""
-  homepage: "https://charm.sh/"
+  homepage: "https://charm.land/"
   brew_commit_author_name: ""
   brew_commit_author_email: ""
   brew_owner: charmbracelet

--- a/goreleaser-vhs.yaml
+++ b/goreleaser-vhs.yaml
@@ -6,7 +6,7 @@ variables:
   binary_name: ""
   description: ""
   maintainer: ""
-  homepage: "https://charm.sh/"
+  homepage: "https://charm.land/"
   brew_commit_author_name: ""
   brew_commit_author_email: ""
   brew_owner: charmbracelet

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -7,7 +7,7 @@ variables:
   description: ""
   github_url: ""
   maintainer: ""
-  homepage: "https://charm.sh/"
+  homepage: "https://charm.land/"
   brew_commit_author_name: ""
   brew_commit_author_email: ""
   brew_owner: charmbracelet

--- a/templates/README.md
+++ b/templates/README.md
@@ -68,7 +68,7 @@ We’d love to hear your thoughts on this project. Feel free to drop us a note!
 
 - [Twitter](https://twitter.com/charmcli)
 - [The Fediverse](https://mastodon.social/@charmcli)
-- [Discord](https://charm.sh/chat)
+- [Discord](https://charm.land/chat)
 
 ## License
 
@@ -76,9 +76,9 @@ We’d love to hear your thoughts on this project. Feel free to drop us a note!
 
 ---
 
-Part of [Charm](https://charm.sh).
+Part of [Charm](https://charm.land).
 
-<a href="https://charm.sh/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge.jpg" width="400"></a>
+<a href="https://charm.land/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge.jpg" width="400"></a>
 
 <!-- prettier-ignore -->
 Charm热爱开源 • Charm loves open source


### PR DESCRIPTION
I didn't touch any `stuff.charm.sh` URLs because it's not configured as an alias or to redirect yet.