### PR TITLE
fix: ignore slog noctx

### DIFF
--- a/golangci.yml
+++ b/golangci.yml
@@ -26,6 +26,10 @@ linters:
     - whitespace
     - wrapcheck
   exclusions:
+    rules:
+      - text: '(slog|log)\.\w+'
+        linters:
+          - noctx
     generated: lax
     presets:
       - common-false-positives


### PR DESCRIPTION
it only makes sense for remote loggers I think, and we don't have any.

With this we can update golangci-lint as well.