### PR TITLE
fix: lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,4 +54,4 @@ jobs:
           working-directory: ${{ github.repository }}
           args: |
             --config="${{ inputs.golangci_path || format('{0}/{1}/meta/golangci.yml', github.workspace, github.repository_owner) }}" --timeout=${{ inputs.timeout || '5m' }} ${{ inputs.directory }}
-          version: ${{ inputs.golangci_version }}
+          version: ${{ inputs.golangci_version || 'v2.4' }}


### PR DESCRIPTION
v2.2 doesn't work with go1.25, and the go action just above it is using go1.25.

We either need to lock both versions, or leave both empty, IMHO.
