### PR TITLE
feat: initial form-based issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,133 @@
+name: "🐞 Submit a bug report"
+description: Report a bug to help us improve!
+title: "bug: [REPLACE ME]"
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thanks for submitting a bug report! 🐞
+
+        - 💬 Make sure to check out the [**discussions**](../discussions) section. If your issue isn't a bug (or you're not sure), and you're looking for help to solve it, please [start a discussion here](../discussions/new?category=q-a) first.
+        - 🔎 Please [**search**](../labels/bug) to see if someone else has submitted a similar bug report, before making a new report.
+  - type: textarea
+    id: description
+    attributes:
+      label: "🌧 Describe the problem"
+      description: A clear and concise description of what the problem is.
+      placeholder: >-
+        Example: "When I attempted to do X, I got X error"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: "⛅ Expected behavior"
+      description: A clear and concise description of what you expected to happen.
+      placeholder: >-
+        Example: "I expected X to let me add Y component, and be successful"
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: "🔄 Minimal reproduction"
+      description: >-
+        Steps to reproduce the behavior (including code examples and/or
+        configuration files if necessary)
+      placeholder: |
+        Example:
+        1. Click on '....'
+        2. Run command with flags --foo --bar, tc
+        3. See error"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: "💠 Version"
+      description: >-
+        What version of the project are you using? Some examples: `v1.2.3`,
+        `master`, `commit 1a2b3c`
+      placeholder: >-
+        Specify your version here.
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: "🖥 Operating system"
+      description: >-
+        What operating system did this issue occur on? Please include architecture
+        (**32bit**, **64bit**, **arm**, **arm64**, etc) and version/distribution
+        information.
+      placeholder: >-
+        Examples: "Linux Ubuntu 22.04 (64bit)", "Windows 11 (64bit)", "macOS 14.2 (arm64)"
+    validations:
+      required: true
+  - type: input
+    id: shell
+    attributes:
+      label: "⌨️ Shell"
+      description: >-
+        What shell are you using? Some examples: `bash`, `zsh`, `fish`,
+        `powershell`, etc.
+      placeholder: >-
+        Specify your shell here.
+    validations:
+      required: true
+  - type: input
+    id: emulator
+    attributes:
+      label: "🖱️ Terminal Emulator"
+      description: >-
+        What terminal emulator are you using? Some examples: `alacritty`, `kitty`,
+        `ghostty`, `wezterm`, `konsole`, `xterm`, `gnome-terminal`, `xfce4-terminal`,
+        `lxterminal`, `rxvt-unicode`, `Windows Terminal`, etc.
+      placeholder: >-
+        Specify your terminal emulator here.
+    validations:
+      required: true
+  - type: input
+    id: multiplexer
+    attributes:
+      label: "⚙️ Terminal Multiplexer (if any)"
+      description: >-
+        What terminal multiplexer are you using (if any)? Some examples: `tmux`,
+        `screen`, `byobu`, etc.
+      placeholder: >-
+        Specify your terminal multiplexer here (if any).
+  - type: markdown
+    attributes:
+      value: >-
+        **Note:** you might encounter rendering issues if your locale does not use
+        `UTF-8` encoding. Please check your locale (`locale` on POSIX systems) to
+        see what encoding is being used by your system.
+  - type: textarea
+    id: context
+    attributes:
+      label: "⚙ Additional context"
+      description: >-
+        Add any other context about the problem here. This includes things
+        like logs, screenshots, code examples, what was the state when the
+        bug occurred?
+      placeholder: >
+        Examples: logs, code snippets, screenshots, os version info, etc
+  - type: checkboxes
+    id: requirements
+    attributes:
+      label: "🤝 Requirements"
+      description: "Please confirm the following:"
+      options:
+        - label: >-
+            I believe the problem I'm facing is a bug, and is not intended
+            behavior. [Post here if you're not sure](../discussions/new?category=q-a).
+          required: true
+        - label: >-
+            I have confirmed that someone else has not
+            [submitted a similar bug report](../labels/bug).
+          required: true
+        - label: >-
+            (optional) I would be willing to contribute a PR to fix this issue.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "🙋‍♂️ Ask the community a question!"
+    about: Have a question, that might not be a bug? Wondering how to solve a problem? Ask away!
+    url: "https://github.com/charmbracelet/REPLACE_ME/discussions/new?category=q-a"
+  - name: "🎉 Show us what you've made!"
+    about: Have you built something using bubbletea, and want to show others? Post here!
+    url: "https://github.com/charmbracelet/REPLACE_ME/discussions/categories/show-and-tell"
+  - name: "💬 Discord chat"
+    about: Chat on our Discord.
+    url: "https://charm.sh/discord"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,86 @@
+name: "💡 Submit a feature request"
+description: Suggest a feature for this project!
+title: "feature: [REPLACE ME]"
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Thanks for submitting a feature request! 💡
+
+        - 💬 Make sure to check out the [**discussions**](../discussions) section of this repository. Do you have an idea for an improvement, but want to brainstorm it with others first? [Start a discussion here](../discussions/new?category=ideas) first.
+        - 🔎 Please [**search**](../labels/enhancement) to see if someone else has submitted a similar feature request, before making a new request.
+  - type: textarea
+    id: describe
+    attributes:
+      label: "✨ Describe the feature you'd like"
+      description: >-
+        A clear and concise description of what you want to happen, or what
+        feature you'd like added.
+      placeholder: 'Example: "It would be cool if X had support for Y"'
+    validations:
+      required: true
+  - type: textarea
+    id: related
+    attributes:
+      label: "🌧 Is your feature request related to a problem?"
+      description: >-
+        A clear and concise description of what the problem is.
+      placeholder: >-
+        Example: "I'd like to see X feature added, as I frequently have to do Y,
+        and I think Z would solve that problem"
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "🔎 Describe alternatives you've considered"
+      description: >-
+        A clear and concise description of any alternative solutions or features
+        you've considered.
+      placeholder: >-
+        Example: "I've considered X and Y, however the potential problems with
+        those solutions would be [...]"
+    validations:
+      required: true
+  - type: dropdown
+    id: breaking
+    attributes:
+      label: "⚠ If implemented, do you think this feature will be a breaking change to users?"
+      description: >-
+        To the best of your ability, do you think implementing this change
+        would impact users during an upgrade process?
+      options:
+        - "No"
+        - "Yes"
+        - "Not sure"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: "⚙ Additional context"
+      description: >-
+        Add any other context or screenshots about the feature request here
+        (attach if necessary).
+      placeholder: "Examples: logs, screenshots, etc"
+  - type: checkboxes
+    id: requirements
+    attributes:
+      label: "🤝 Requirements"
+      description: "Please confirm the following:"
+      options:
+        - label: >-
+            I have confirmed that someone else has not
+            [submitted a similar feature request](../labels/enhancement).
+          required: true
+        - label: >-
+            If implemented, I believe this feature will help others, in
+            addition to solving my problems.
+          required: true
+        - label: I have looked into alternative solutions to the best of my ability.
+          required: true
+        - label: >-
+            (optional) I would be willing to contribute to testing this
+            feature if implemented, or making a PR to implement this
+            functionality.
+          required: false


### PR DESCRIPTION
### Describe your changes

Adding a few initial designs for issue templates that can be used across charmbracelet repos. The newer form templates for issues are nice for a few reasons:
- More explicitly identifiable fields for filling in information (incl. dropdowns, checkboxes, inputs, textareas, etc)
- Markdown can be rendered inline to highlight important info for those submitting bug reports/feature requests
- Requiring specific fields to be populated before users can submit
- Each field has an `id`, which you can auto-fill in the URL. this is useful for something like **crush**, where you could have a `crush report` command that generates a URL with the information it can auto-gather already filled in for users, so they don't have to specify it.

I've tried to make the templates themselves generic so they are applicable to as many of the charm repos as possible. Generic wording, not necessarily specifying the project name, etc. The `config.yml` doesn't support relative URLs, so it would have to be configured on a per-repo basis, where-as everything else could technically be automatically synced across all repos if you wanted to.

#### Goals

- Try and push folks to look at existing issues before submitting theirs, so they can contribute to already-open issues rather than creating potentially duplicate issues.
- Ensure it's more likely for users to fill in information.
- For features in particular, some of the questions I've added will hopefully solve some of the [XY](https://xyproblem.info/) issues I've seen before. 

#### Specific changes

- bug report, with fields for os/arch, shell, emulator, multiplexer, reproduction, etc.
- feature request, with questions designed to elicit more useful input than the current forms.
- `config.yml` also includes emojis to make each form stand out more, and also link to discussions for show & tell and Q&A.

### Demo

I have the changes here merged into `master` on my fork, so you can get an idea of what they look like:

- issue chooser: https://github.com/lrstanley/charmbracelet-meta/issues/new/choose
- bug report: https://github.com/lrstanley/charmbracelet-meta/issues/new?template=bug_report.yml
- feature request: https://github.com/lrstanley/charmbracelet-meta/issues/new?template=feature_request.yml
- example of some fields pre-filled in: https://github.com/lrstanley/charmbracelet-meta/issues/new?template=bug_report.yml&version=v0.6.2&os=Ubuntu+22.04+(x64)&shell=bash&emulator=ghostty&multiplexer=tmux

### Notes for Reviewer

- For things like Charm, you will probably want additional fields for provider and model used (though maybe optional, as some issues aren't applicable to the provider/model)
- Thoughts on pre-filling in the title? and if yes, are the pre-filled in titles ok? may mean issues come in more frequently with the `feature` and `bug` prefixes.
- For things like shell, emulator, multiplexer, do we want to ask for versions for those by default?
- For some of the fields, I did an input, whereas I could do a dropdown. Dropdowns are nicer for the end user, but has the downside that you can't easily capture an "other" option. E.g. os could have dropdown items for `linux/ubuntu`, linux/arch`, `linux/other`, `windows/11`, `windows/10`, `macos/<version>`, etc.
  - Dropdowns also make it easier to have a triage GH action that auto-labels issues based off common patterns seen in the dropdown. E.g. the OS example could allow labels to be automatically added for `linux`, `windows`, etc.
  - Let me know if you'd rather see dropdowns for these, with wording for if `other` is chosen, to have them put that in the `Additional Details` field.
- Potential future state: dynamically sync these to other repos, with a template engine so it's easier to keep a central list of operating system, terminal emulators, etc and people could then select them from a dropdown.

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code