### PR TITLE
chore: group dependabot updates to reduce noise

### DIFF
--- a/dependabot/dependabot-bubbletea.yml
+++ b/dependabot/dependabot-bubbletea.yml
@@ -11,6 +11,10 @@
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/tutorials"
@@ -24,3 +28,7 @@
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/dependabot/dependabot-colorprofile.yml
+++ b/dependabot/dependabot-colorprofile.yml
@@ -11,6 +11,10 @@
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/tutorials"
@@ -24,3 +28,7 @@
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/dependabot/dependabot-huh.yml
+++ b/dependabot/dependabot-huh.yml
@@ -11,6 +11,10 @@
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/spinner"
@@ -24,3 +28,7 @@
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/dependabot/dependabot-lipgloss.yml
+++ b/dependabot/dependabot-lipgloss.yml
@@ -11,3 +11,7 @@
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/dependabot/dependabot-soft-serve-action.yml
+++ b/dependabot/dependabot-soft-serve-action.yml
@@ -6,3 +6,7 @@
       day: "monday"
       time: "05:00"
       timezone: "America/New_York"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/dependabot/dependabot-vhs-action.yml
+++ b/dependabot/dependabot-vhs-action.yml
@@ -6,3 +6,7 @@
       day: "monday"
       time: "05:00"
       timezone: "America/New_York"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/dependabot/dependabot-wish.yml
+++ b/dependabot/dependabot-wish.yml
@@ -11,3 +11,7 @@
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/dependabot/dependabot.yml
+++ b/dependabot/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -26,6 +30,10 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -39,3 +47,7 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
Consider this PR a proposal. Let me know if you disagree with this.

We currently have a lot of noise on these PRs, because we have several repos and several PRs are opened on each every week. I think it probably makes sense to group all updates in a single PR so the noise is greatly reduced. Most of the time we're going to merge all updates anyway...

Potential con: if a given update causes a test to fail, the whole PR will be unable to be merged, and we'll need manual intervation to get these dependencies updated.

---

Crush has its own PR because it disabled the Dependabot config sync for Crush:

* https://github.com/charmbracelet/crush/pull/891