### PR TITLE
fix: make dependabot stop suggesting bubbletea v2-beta1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       prefix: "chore"
       include: "scope"
     ignore:
-      - dependency-name: github.com/charmbracelet/lipgloss/v2
+      - dependency-name: github.com/charmbracelet/bubbletea/v2
         versions:
           - v2.0.0-beta1
 

--- a/dependabot/dependabot-huh.yml
+++ b/dependabot/dependabot-huh.yml
@@ -16,7 +16,7 @@
         patterns:
           - "*"
     ignore:
-      - dependency-name: github.com/charmbracelet/lipgloss/v2
+      - dependency-name: github.com/charmbracelet/bubbletea/v2
         versions:
           - v2.0.0-beta1
 
@@ -37,6 +37,6 @@
         patterns:
           - "*"
     ignore:
-      - dependency-name: github.com/charmbracelet/lipgloss/v2
+      - dependency-name: github.com/charmbracelet/bubbletea/v2
         versions:
           - v2.0.0-beta1

--- a/dependabot/dependabot-wish.yml
+++ b/dependabot/dependabot-wish.yml
@@ -16,6 +16,6 @@
         patterns:
           - "*"
     ignore:
-      - dependency-name: github.com/charmbracelet/lipgloss/v2
+      - dependency-name: github.com/charmbracelet/bubbletea/v2
         versions:
           - v2.0.0-beta1

--- a/dependabot/dependabot.yml
+++ b/dependabot/dependabot.yml
@@ -18,7 +18,7 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: github.com/charmbracelet/lipgloss/v2
+      - dependency-name: github.com/charmbracelet/bubbletea/v2
         versions:
           - v2.0.0-beta1
 


### PR DESCRIPTION
it should stop it from suggestion v2-beta1 over v2-beta.3