### PR TITLE
chore: update changelog section header titles

### DIFF
--- a/goreleaser-full.yaml
+++ b/goreleaser-full.yaml
@@ -224,19 +224,19 @@ changelog:
       - Merge branch
       - go mod tidy
   groups:
-    - title: Dependency updates
+    - title: "Deps"
       regexp: "^.*\\(deps\\)*:+.*$"
       order: 300
-    - title: "New Features"
+    - title: "New!"
       regexp: "^.*feat[(\\w)]*:+.*$"
       order: 100
-    - title: "Bug fixes"
+    - title: "Fixed"
       regexp: "^.*fix[(\\w)]*:+.*$"
       order: 200
-    - title: "Documentation updates"
+    - title: "Docs"
       regexp: "^.*docs[(\\w)]*:+.*$"
       order: 400
-    - title: Other work
+    - title: "Other stuff"
       order: 9999
 
 signs:

--- a/goreleaser-lib.yaml
+++ b/goreleaser-lib.yaml
@@ -17,19 +17,19 @@ changelog:
       - Merge branch
       - go mod tidy
   groups:
-    - title: Dependency updates
+    - title: "Deps"
       regexp: "^.*\\(deps\\)*:+.*$"
       order: 300
-    - title: "New Features"
+    - title: "New!"
       regexp: "^.*feat[(\\w)]*:+.*$"
       order: 100
-    - title: "Bug fixes"
+    - title: "Fixed"
       regexp: "^.*fix[(\\w)]*:+.*$"
       order: 200
-    - title: "Documentation updates"
+    - title: "Docs"
       regexp: "^.*docs[(\\w)]*:+.*$"
       order: 400
-    - title: Other work
+    - title: "Other stuff"
       order: 9999
 
 git:


### PR DESCRIPTION
This (hopefully) updates the headers to match the tone used in the release notes. I usually do this by hand every release in Crush, and often elsewhere.